### PR TITLE
Fix problem with issue not being a dictionary

### DIFF
--- a/autoload/issue/provider/github.vim
+++ b/autoload/issue/provider/github.vim
@@ -103,7 +103,7 @@ function! s:parse_issues(issues, repo, roster) " {{{
 	let candidates = []
 	for issue in a:issues
 		let repo = a:repo
-		if len(repo) == 0 && has_key(issue, 'repository')
+		if len(repo) == 0 && type(issue) == type({}) && has_key(issue, 'repository')
 			let repo = issue.repository.full_name
 		endif
 


### PR DESCRIPTION
I found that in NeoVim, the command issue:github failed because of:

```
[unite.vim] function <SNR>89_call_unite..unite#start..unite#start#standard..unite#candidates#_recache..<SNR>104_recache_candidates_loop..<SNR>104_get_source_candidates..108..issue#provider#github#fetch_issues..<SNR>107_parse_issues, line 6
[unite.vim] Vim(if):E715: Dictionary required
[unite.vim] Error occurred in gather_candidates!
[unite.vim] Source name is issue
Press ENTER or type command to continue
```

I never wrote, or almost read VimL, except for a few little thing in my rc...
I found that adding this extra check, the error vanishes, and everything seems
to work fine.
