### PR TITLE
Fixing config option for custim header in example

### DIFF
--- a/doc/unite-issue.txt
+++ b/doc/unite-issue.txt
@@ -186,7 +186,7 @@ JIRA:
 	let g:jira_password = 'meemeep'
 
 	" Add custom special header, e.g. Cookie
-	let g:jira_request_header = {
+	let g:unite_source_issue_jira_request_header = {
 		\ 'Cookie': 'MYSPECIALCOOKIE=I_am_allowed_here' }
 
 	" Customize


### PR DESCRIPTION
Fixed the name for the custom header variables in the Example.
