### PR TITLE
escape '@' characters in username

### DIFF
--- a/autoload/issue/provider/jira.vim
+++ b/autoload/issue/provider/jira.vim
@@ -61,7 +61,7 @@ function! issue#provider#jira#fetch_issues(arg, context, roster) " {{{
 	" argument, e.g. -custom-issue-jql=project=FOO\ AND\ assignee=joe
 	let jql = get(a:context, 'custom_issue_jql', '')
 	if len(jql) == 0
-		let jql = s:jira_build_jql({'assignee' : g:jira_username, 'resolution': 'unresolved', 'project':  a:arg})
+		let jql = s:jira_build_jql({'assignee' : substitute(g:jira_username, '@', '\\\\u0040', ''), 'resolution': 'unresolved', 'project':  a:arg})
 	endif
 
 	call unite#print_source_message('Fetch JIRA: '.jql, 'issue')


### PR DESCRIPTION
jira throws an error if an '@' character appears in a JQL query:

```
{"errorMessages":["Error in the JQL Query: The character '@' is a reserved JQL character.
You must enclose it in a string or use the escape '\\u0040' instead. (line 1, character 14)"],
"errors":{}}
```

escape usernames based on email addresses to avoid the error.  this should probably be more generic (in `jira_build_jql`?) and escape any other reserved JQL characters.